### PR TITLE
fix: save source code to hexo-source and deploy to master

### DIFF
--- a/source/docs/github-pages.md
+++ b/source/docs/github-pages.md
@@ -20,7 +20,7 @@ node_js:
 cache: npm
 branches:
   only:
-    - master # build master branch only
+    - hexo-source # store source code in hexo-source branch
 script:
   - hexo generate # generate static files
 deploy:
@@ -28,8 +28,9 @@ deploy:
   skip-cleanup: true
   github-token: $GH_TOKEN
   keep-history: true
+  target_branch: master # generate static files to master
   on:
-    branch: master
+    branch: hexo-source # read source from hexo-source branch
   local-dir: public
 ```
 9. Once Travis CI finish the deployment, the generated pages can be found in the `gh-pages` branch of your repository


### PR DESCRIPTION
As user page, Github must be built from only the master branch, but the origin config in .travis.yml is deployed static pages to gh-pages. That can only result in 404 when viewing usename.github.io.

## Check List

**Please read and check followings before submitting a PR.**

- [x] I want to publish my theme on Hexo official website.
    - [x] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [x] `name` is unique.
    - [x] `link` URL is correct.
    - [x] `preview` URL is correct.
    - [x] `preview` URL web site is rendered correctly.
    - [x] Add a screenshot to `source/themes/screenshots`.
    - [x] Screenshot filename is same as value of `name`.
    - [x] Screenshot size is `800 * 500`.
    - [x] Screenshot file format is `png`.
- [x] I want to publish my plugin on Hexo official website.
    - [x] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [x] `name` is unique.
    - [x] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)
    - Languages:
    - [x] `en` English
    - [x] `ko` Korean
    - [x] `pt-br` Brazilian Portuguese
    - [x] `ru` Russian
    - [x] `th` Thai
    - [x] `zh-cn` simplified Chinese
    - [x] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
